### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-stable]
         os: [ubuntu-latest]
         include:
@@ -20,11 +20,17 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "league/commonmark": "^2.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "phpstan/phpstan-deprecation-rules": "^1.1.1|^2.0",
         "phpstan/phpstan-phpunit": "^1.3.3|^2.0",
         "phpunit/phpunit": "^10.5|^11.0|^12.0",


### PR DESCRIPTION
- Add PHP 8.5 to test matrix
- Add Laravel 13.* with testbench 11.* to test matrix
- Exclude Laravel 13 from PHP 8.1 and 8.2 compatibility
- Expand illuminate/contracts to include ^13.0
- Expand orchestra/testbench to include ^10.0|^11.0