### PR TITLE
feat!: drop EOL Laravel 10 + PHP 8.1 (require L11+, PHP 8.2+)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,13 +9,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-stable]
         os: [ubuntu-latest]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
@@ -23,12 +21,6 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
         exclude:
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
-          - laravel: 13.*
-            php: 8.1
           - laravel: 13.*
             php: 8.2
 

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "league/commonmark": "^2.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "phpstan/phpstan-deprecation-rules": "^1.1.1|^2.0",
         "phpstan/phpstan-phpunit": "^1.3.3|^2.0",
-        "phpunit/phpunit": "^10.5|^11.0|^12.0",
+        "phpunit/phpunit": "^11.0|^12.0",
         "spatie/phpunit-snapshot-assertions": "^5.0"
     },
     "autoload": {


### PR DESCRIPTION
## What

Drop end-of-life Laravel 10 and PHP 8.1. New minimums:

- `php`: `^8.1` → `^8.2`
- `illuminate/contracts`: `^10.0|^11.0|^12.0|^13.0` → `^11.0|^12.0|^13.0`
- `orchestra/testbench` (dev): `^8.0|^9.0|^10.0|^11.0` → `^9.0|^10.0|^11.0`
- `phpunit/phpunit` (dev): `^10.5|^11.0|^12.0` → `^11.0|^12.0`
- CI matrix: drop PHP 8.1 and Laravel 10.* (+ the L10/testbench-8 include and the now-dead 8.1 excludes; kept the L13×8.2 exclude since Laravel 13 requires PHP ^8.3)

## Why

Laravel 10 hit security-EOL in **Feb 2025** and PHP 8.1 in **Nov 2025**. Removing supported versions from the constraint is consumer-breaking, so this is a **major release**.

## Decision: strict EOL-only

Kept **Laravel 11** (security until ~Aug 2026) and **PHP 8.2** (until Dec 2026) — neither is EOL yet. More aggressive `^12|^13` / PHP `^8.3` available on request.

## Verification

Local: `composer update --prefer-stable` resolves to **Laravel 13.11.2 + testbench 11.3.3 + PHPUnit 12.5.27** on **PHP 8.5** — `vendor/bin/phpunit` → **4/4 pass** (2 incomplete = spatie snapshot-creation placeholders, pre-existing). Full matrix runs in CI on this PR.

## Release

Tag **`3.0.0`** on merge (BREAKING CHANGE). composer.lock is gitignored; no lockfile change.