### PR TITLE
chore(ci): canary — PR-based signed-merge flow (branch-protection enablement)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -50,4 +50,5 @@ jobs:
             echo "::error::Test suite did not pass for ${HEAD_SHA}; not auto-merging."
             exit 1
           fi
-          gh pr merge --merge "$PR_URL"
+          # Squash (not merge) to keep main's linear history under the branch ruleset.
+          gh pr merge --squash "$PR_URL"

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,6 +1,11 @@
 name: Check & Fix code style
 
-on: [push]
+# PR-based flow: Pint runs on pull requests and commits style fixes to the PR
+# head branch. It NO LONGER pushes directly to main — main is protected by a
+# branch ruleset (require PR + signed commits + linear history). Style fixes
+# reach main only through the squash-merge of the PR, which GitHub signs.
+on:
+  pull_request:
 
 permissions:
   contents: write
@@ -8,6 +13,7 @@ permissions:
 jobs:
   php-code-styling:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -18,7 +24,7 @@ jobs:
       - name: Fix code styling issues
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
-      - name: Commit changes
+      - name: Commit changes to the PR branch
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'style: resolve style guide violations'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,12 +1,23 @@
 name: "Update Changelog"
 
+# PR-based flow: on a release, update CHANGELOG.md on a dedicated branch, open
+# a PR, and squash-merge it. The squash commit is created by GitHub and is
+# therefore SIGNED — satisfying the `required_signatures` rule on main. We do
+# NOT push directly to main (blocked by the `pull_request` rule). The bot can
+# merge because the ruleset requires 0 approvals (solo repo); admin bypass keeps
+# Mau's own direct access intact.
 on:
   release:
     types: [released]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -20,9 +31,25 @@ jobs:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
-        with:
-          branch: main
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
+      - name: Open and squash-merge the changelog PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.event.release.name }}
+        run: |
+          set -euo pipefail
+          branch="changelog/${VERSION}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # No-op guard: if the action produced no changes, do nothing.
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md unchanged; nothing to do."
+            exit 0
+          fi
+          git switch -c "$branch"
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG for ${VERSION}"
+          git push origin "$branch"
+          gh pr create --base main --head "$branch" \
+            --title "Update CHANGELOG for ${VERSION}" \
+            --body "Automated changelog update for ${VERSION}."
+          gh pr merge "$branch" --squash --delete-branch


### PR DESCRIPTION
Canary for the branch-protection rework. Converts the three direct-push workflows to a PR-based, squash-merge (GitHub-signed) flow so main can enforce require-PR + signed commits + linear history without breaking automation. Roll out to the other 3 OSS repos only after this proves out across a live release + dependabot cycle.