### PR TITLE
fix(ci): pint check-only (no codebase mutation)

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,14 +1,15 @@
-name: Check & Fix code style
+name: Check code style
 
-# PR-based flow: Pint runs on pull requests and commits style fixes to the PR
-# head branch. It NO LONGER pushes directly to main — main is protected by a
-# branch ruleset (require PR + signed commits + linear history). Style fixes
-# reach main only through the squash-merge of the PR, which GitHub signs.
+# CI check ONLY — fails if there are style violations, never mutates the codebase.
+# Developers fix style locally (`pint`) and push; CI just verifies. This keeps
+# every check non-mutating (no commit back to any branch), which is required for
+# the protected `main` (no direct pushes) and is the project-wide CI principle.
+# The changelog updater is the sole workflow permitted to change the codebase.
 on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   php-code-styling:
@@ -18,13 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.head_ref }}
 
-      - name: Fix code styling issues
+      - name: Check code style (fail on violations, no changes)
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
-
-      - name: Commit changes to the PR branch
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
-          commit_message: 'style: resolve style guide violations'
+          testMode: true


### PR DESCRIPTION
CI checks must fail on violations, not mutate the codebase. Pint now runs in testMode (contents: read, no commit). Also live-exercises markdown's protected-main PR+signed+squash flow.