### PR TITLE
chore(ci): add Composer audit gate and composer-normalize

### DIFF
--- a/.github/workflows/composer-security.yml
+++ b/.github/workflows/composer-security.yml
@@ -1,0 +1,36 @@
+# managed-by: ComposerSecurityStamp (profile=oss) — edit the stamp, not this file
+name: Composer Security
+
+permissions:
+  contents: read
+
+on:
+  push:
+    paths:
+      - 'composer.json'
+      - '.github/workflows/composer-security.yml'
+  pull_request:
+  schedule:
+    - cron: '27 6 * * 1'  # weekly — catches deps newly flagged in an unchanged lockfile
+
+jobs:
+  audit:
+    name: Malware & advisory audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup PHP + pinned Composer
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          php-version: '8.4'
+          tools: composer:2.10
+          coverage: none
+
+      - name: Resolve dependencies (library ships no lock)
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Audit (Composer >= 2.10 fails on malware + advisories)
+        run: composer audit

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,12 @@
 {
     "name": "lemaur/markdown",
     "description": "Another Markdown parsers but with super powers",
+    "license": "MIT",
     "keywords": [
         "lemaur",
         "laravel",
         "markdown"
     ],
-    "homepage": "https://github.com/lemaur/markdown",
-    "license": "MIT",
     "authors": [
         {
             "name": "Maurizio",
@@ -15,20 +14,24 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://github.com/lemaur/markdown",
     "require": {
         "php": "^8.2",
-        "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^11.0|^12.0|^13.0",
-        "league/commonmark": "^2.0"
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+        "league/commonmark": "^2.0",
+        "spatie/laravel-package-tools": "^1.4.3"
     },
     "require-dev": {
+        "ergebnis/composer-normalize": "^2.42",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
-        "phpstan/phpstan-deprecation-rules": "^1.1.1|^2.0",
-        "phpstan/phpstan-phpunit": "^1.3.3|^2.0",
-        "phpunit/phpunit": "^11.0|^12.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "phpstan/phpstan-deprecation-rules": "^1.1.1 || ^2.0",
+        "phpstan/phpstan-phpunit": "^1.3.3 || ^2.0",
+        "phpunit/phpunit": "^11.0 || ^12.0",
         "spatie/phpunit-snapshot-assertions": "^5.0"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Lemaur\\Markdown\\": "src"
@@ -39,13 +42,22 @@
             "Lemaur\\Markdown\\Tests\\": "tests"
         }
     },
-    "scripts": {
-        "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
-        "format": "vendor/bin/pint"
-    },
     "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        },
+        "policy": {
+            "advisories": {
+                "block": true
+            },
+            "malware": {
+                "block": true,
+                "block-scope": "all"
+            },
+            "abandoned": {
+                "audit": "report"
+            }
+        },
         "sort-packages": true
     },
     "extra": {
@@ -55,6 +67,11 @@
             ]
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "scripts": {
+        "post-autoload-dump": "composer normalize",
+        "analyse": "vendor/bin/phpstan analyse",
+        "format": "vendor/bin/pint",
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+    }
 }


### PR DESCRIPTION
## What

- Add `.github/workflows/composer-security.yml` — a dedicated security workflow that runs `composer audit` on push (when `composer.json` or the workflow changes), on every pull request, and weekly via cron.
- Add a `config.policy` block to `composer.json`: block on malware and advisories, report abandoned packages (Composer ≥ 2.10).
- Add `ergebnis/composer-normalize` (`^2.42`) with a `post-autoload-dump` hook and the matching `allow-plugins` entry, keeping `composer.json` normalized.

## Why

`composer audit` (Composer ≥ 2.10) fails on malicious packages and known advisories by default. Running it as its own job — separate from build/test, with a `contents: read` token — means a newly disclosed advisory in the dependency tree breaks CI on its own, including weeks after a change via the weekly run. The package ships no lockfile, so the job resolves with `composer update` to audit the versions a fresh install would actually pull.

Composer is pinned to `2.10` and the actions are pinned to commit SHAs so the gate's behaviour can't drift underneath us.

## Verification

- `composer audit` — clean (no advisories) against freshly resolved dependencies.
- `composer validate` — valid.
- `composer normalize --dry-run` — already normalized.
- Test suite green (4 tests).